### PR TITLE
add app namespace context option

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -29,6 +29,8 @@ var topLevelProperties = function(msg){
   var languageLocale = msg.proxy('context.locale').split('-');
   var language = languageLocale[0];
   var locale = languageLocale[1];
+  var namePostfix = msg.proxy('context.Criteo.namePostfix');
+  var namespace = app.namespace;
   var siteType;
 
   if (os.name === 'Android') {
@@ -39,9 +41,13 @@ var topLevelProperties = function(msg){
     deviceId = { 'idfa': deviceId };
   }
 
+  if (namePostfix) {
+    namespace = namespace + '.' + namePostfix;
+  }
+
   return {
     account: {
-      an: app.namespace,
+      an: namespace,
       cn: lower(locale),
       ln: lower(language)
     },

--- a/test/fixtures/track-namespace-postfix.json
+++ b/test/fixtures/track-namespace-postfix.json
@@ -1,0 +1,60 @@
+{
+  "input": {
+    "type": "track",
+    "event": "Cart Viewed",
+    "userId": "user-id",
+    "properties": {
+      "cartId": "d92jd29jd92jd29j92d92jd",
+        "products": [
+          { "productId": "1", "price": "19", "quantity": "1" },
+          { "productId": "2", "price": "3", "quantity": "2" }
+        ]
+    },
+    "timestamp": "2015-11-09",
+    "context": {
+      "ip": "10.0.0.2",
+      "app": {
+        "namespace": "com.segment.TestApp",
+        "version": 2
+      },
+      "device": {
+        "manufacturer": "some-brand",
+        "type": "ios",
+        "advertisingId": "159358",
+        "id": "CECBF993-BA22-4BBF-9DE2-04DE813505CA"
+      },
+      "Criteo": { "namePostfix": "flights" },
+      "network": { "carrier": "some-carrier" },
+      "locale": "en-US",
+      "library": {
+        "name": "analytics-ios"
+      },
+      "os": {
+        "name": "iOS"
+      },
+      "referrer": {
+        "type": "iad",
+        "id": "some-id"
+      }
+    }
+  },
+  "output": {
+    "account": {
+      "an": "com.segment.TestApp.flights",
+      "cn": "us",
+      "ln": "en"
+    },
+    "site_type": "aios",
+    "id": { "idfa": "CECBF993-BA22-4BBF-9DE2-04DE813505CA" },
+    "events": { 
+      "event": "viewBasket",
+      "ci": "user-id",
+      "currency": "USD",
+      "product": [
+        { "id": "1", "price": "19", "quantity": "1" },
+        { "id": "2", "price": "3", "quantity": "2" }
+      ]
+    },
+    "version": "s2s_v1.0.0"
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -102,6 +102,10 @@ describe('Criteo', function(){
       it('should map events with correct country codes', function(){
         test.maps('track-country');
       });
+
+      it('should map events with a name postfix', function(){
+        test.maps('track-namespace-postfix');
+      });
     });
   });
 


### PR DESCRIPTION
#Criteo allows customers to specify an additional value to be appended to the app's namespace to allow for more differentiation in their tool. (i.e. Kayak might append flights, hotels, cars their app namespace)

This change allows them to achieve this via a Criteo object in the context object like https://github.com/segment-integrations/integration-mixpanel/blob/master/lib/index.js#L67

After this change it will be ready for release

@sperand-io @ndhoule @hankim813 