### PR TITLE
Remove screen mapper method

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+1.2.8 / 2017-05-23
+==================
+
+  * Remove screen mapper method to fix exceptions
+
 1.2.7 / 2017-05-23
 ==================
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -369,15 +369,3 @@ exports.orderCompleted = function(track) {
 exports.page = function(page) {
   return page;
 };
-
-/**
- * Map screen.
- *
- * @param {Screen} screen
- * @return {Object}
- * @api private
- */
-
-exports.screen = function(screen) {
-  return screen;
-};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-criteo",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "integration-criteo server-side integration",
   "author": "Segment <friends@segment.com>",
   "main": "lib/index.js",


### PR DESCRIPTION
This is causing the integration to throw uncaught exceptions. We
should add this back in and add a corresponding method to
lib/index.js, or we could not support screen calls in this
integration.